### PR TITLE
Test arguments in update method.

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,10 @@ class Main(KytosNApp):
         except KeyError:
             return jsonify({'response': f'Maintenance with id {mw_id} not '
                                         f'found'}), 404
-        maintenance.update(data, self.controller)
+        try:
+            maintenance.update(data, self.controller)
+        except ValueError as error:
+            return jsonify(f'{error}'), 400
         return jsonify({'response': f'Maintenance {mw_id} updated'}), 201
 
     @rest('/<mw_id>', methods=['DELETE'])

--- a/models.py
+++ b/models.py
@@ -66,10 +66,21 @@ class MaintenanceWindow:
 
     def update(self, mw_dict, controller):
         """Update a maintenance window with the data from a dictionary."""
-        if 'start' in mw_dict:
-            self.start = self.str_to_datetime(mw_dict['start'])
-        if 'end' in mw_dict:
-            self.end = self.str_to_datetime(mw_dict['end'])
+        try:
+            start = self.str_to_datetime(mw_dict['start'])
+        except KeyError:
+            start = self.start
+        try:
+            end = self.str_to_datetime(mw_dict['end'])
+        except KeyError:
+            end = self.end
+        now = datetime.datetime.now(pytz.utc)
+        if start < now:
+            raise ValueError('Start in the past not allowed.')
+        if end < start:
+            raise ValueError('End before start not allowed.')
+        self.start = start
+        self.end = end
         if 'items' in mw_dict:
             self.items = self.get_items(mw_dict['items'], controller)
 


### PR DESCRIPTION
Start and end datetimes are now tested if valid.
Start must be in the future and end must be after start.
Fix #2.