### PR TITLE
Update setup.py to solve "No such file or directory" error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ class DevelopMode(develop):
             shutil.rmtree(str(ENABLED_PATH), ignore_errors=True)
         else:
             self._create_folder_symlinks()
-            self._create_file_symlinks()
+            #self._create_file_symlinks()
             KytosInstall.enable_core_napps()
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ class DevelopMode(develop):
             shutil.rmtree(str(ENABLED_PATH), ignore_errors=True)
         else:
             self._create_folder_symlinks()
-            #self._create_file_symlinks()
+            # self._create_file_symlinks()
             KytosInstall.enable_core_napps()
 
     @staticmethod


### PR DESCRIPTION
Today, an error is raised in maintenance Kytos napp installation:

[Errno 2] No such file or directory: 'maintenance/napps/__init__.py'

This commit comments self._create_file_symlinks() line to solve this problem.

Fix #21 