### PR TITLE
Check state before deleting or modifying

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from flask import jsonify, request
 
 from kytos.core import KytosNApp, rest
 from napps.kytos.maintenance.models import MaintenanceWindow as MW
-from napps.kytos.maintenance.models import Scheduler
+from napps.kytos.maintenance.models import Scheduler, Status
 
 
 class Main(KytosNApp):
@@ -90,6 +90,9 @@ class Main(KytosNApp):
         except KeyError:
             return jsonify({'response': f'Maintenance with id {mw_id} not '
                                         f'found'}), 404
+        if maintenance.status == Status.RUNNING:
+            return jsonify({'response': f'Updating a running maintenance is '
+                                        f'not allowed'}), 400
         try:
             maintenance.update(data)
         except ValueError as error:
@@ -104,6 +107,9 @@ class Main(KytosNApp):
         except KeyError:
             return jsonify({'response': f'Maintenance with id {mw_id} not '
                                         f'found'}), 404
+        if maintenance.status == Status.RUNNING:
+            return jsonify({'response': f'Deleting a running maintenance is '
+                                        f'not allowed'}), 400
         self.scheduler.remove(maintenance)
         del self.maintenances[mw_id]
         return jsonify({'response': f'Maintenance with id {mw_id} '

--- a/main.py
+++ b/main.py
@@ -91,8 +91,8 @@ class Main(KytosNApp):
             return jsonify({'response': f'Maintenance with id {mw_id} not '
                                         f'found'}), 404
         if maintenance.status == Status.RUNNING:
-            return jsonify({'response': f'Updating a running maintenance is '
-                                        f'not allowed'}), 400
+            return jsonify({'response': 'Updating a running maintenance is '
+                                        'not allowed'}), 400
         try:
             maintenance.update(data)
         except ValueError as error:
@@ -108,8 +108,8 @@ class Main(KytosNApp):
             return jsonify({'response': f'Maintenance with id {mw_id} not '
                                         f'found'}), 404
         if maintenance.status == Status.RUNNING:
-            return jsonify({'response': f'Deleting a running maintenance is '
-                                        f'not allowed'}), 400
+            return jsonify({'response': 'Deleting a running maintenance is '
+                                        'not allowed'}), 400
         self.scheduler.remove(maintenance)
         del self.maintenances[mw_id]
         return jsonify({'response': f'Maintenance with id {mw_id} '

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -10,6 +10,7 @@ import pytz
 from tests.helpers import get_controller_mock
 from napps.kytos.maintenance.main import Main
 from napps.kytos.maintenance.models import MaintenanceWindow as MW
+from napps.kytos.maintenance.models import Status
 
 TIME_FMT = "%Y-%m-%dT%H:%M:%S"
 
@@ -296,7 +297,7 @@ class TestMain(TestCase):
     @patch('napps.kytos.maintenance.models.Scheduler.remove')
     def test_remove_mw_case_2(self, sched_remove_mock):
         """Test remove existent id."""
-        start1 = datetime.now(pytz.utc) + timedelta(days=1)
+        start1 = datetime.now(pytz.utc) + timedelta(hours=1)
         end1 = start1 + timedelta(hours=6)
         start2 = datetime.now(pytz.utc) + timedelta(hours=5)
         end2 = start2 + timedelta(hours=1, minutes=30)
@@ -314,8 +315,29 @@ class TestMain(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(current_data, {'response': 'Maintenance with id 1234 '
                                                     'successfully removed'})
+
         sched_remove_mock.assert_called_once()
         self.assertEqual(len(self.napp.maintenances), 1)
+
+    def test_remove_mw_case_3(self):
+        """Test remove existent id."""
+        start1 = datetime.now(pytz.utc) - timedelta(days=1)
+        end1 = start1 + timedelta(hours=6)
+        start2 = datetime.now(pytz.utc) + timedelta(hours=5)
+        end2 = start2 + timedelta(hours=1, minutes=30)
+        self.napp.maintenances = {
+            '1234': MW(start1, end1, self.controller, status=Status.RUNNING,
+                       items=['00:00:00:00:00:00:12:23']),
+            '4567': MW(start2, end2, self.controller, items=[
+                '12:34:56:78:90:ab:cd:ef'
+            ])
+        }
+        url = f'{self.server_name_url}/1234'
+        response = self.api.delete(url)
+        current_data = json.loads(response.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(current_data, {'response': 'Deleting a running mainte'
+                                                    'nance is not allowed'})
 
     def test_update_mw_case_1(self):
         """Test update non-existent id."""


### PR DESCRIPTION
 Fix #36

### :bookmark_tabs: Description of the Change

Update and delete maintenance now checks the state of the maintenance. If it is
running, the procedure is cancelled and an error code is returned.

### :computer: Verification Process

Unit test was coded and all unit tests passed

### :page_facing_up: Release Notes

- Fix an issue where updates and deletes were allowed when the maintenance is running.
