### PR TITLE
Update scheduler on maintenance update

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,6 +94,8 @@ class Main(KytosNApp):
             maintenance.update(data)
         except ValueError as error:
             return jsonify(f'{error}'), 400
+        self.scheduler.remove(maintenance)
+        self.scheduler.add(maintenance)
         return jsonify({'response': f'Maintenance {mw_id} updated'}), 201
 
     @rest('/<mw_id>', methods=['DELETE'])

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -367,8 +367,11 @@ class TestMain(TestCase):
         self.assertEqual(current_data,
                          'Bad request: The request do not have a json.')
 
+    @patch('napps.kytos.maintenance.models.Scheduler.add')
+    @patch('napps.kytos.maintenance.models.Scheduler.remove')
     @patch('napps.kytos.maintenance.models.MaintenanceWindow.update')
-    def test_update_mw_case_3(self, mw_update_mock):
+    def test_update_mw_case_3(self, mw_update_mock, sched_remove_mock,
+                              sched_add_mock):
         """Test successful update."""
         start1 = datetime.now(pytz.utc) + timedelta(days=1)
         end1 = start1 + timedelta(hours=6)
@@ -394,6 +397,8 @@ class TestMain(TestCase):
         self.assertEqual(current_data,
                          {'response': 'Maintenance 1234 updated'})
         mw_update_mock.assert_called_once_with(payload)
+        sched_add_mock.assert_called_once()
+        sched_remove_mock.assert_called_once()
 
     @patch('napps.kytos.maintenance.models.MaintenanceWindow.update')
     def test_update_mw_case_4(self, mw_update_mock):


### PR DESCRIPTION
Fix #40

### :bookmark_tabs: Description of the Change

When a maintenance was updated, the scheduler was left untouched.
Now, the scheduler is removed and then added again to reflect
the changes made by the update.

### :computer: Verification Process

Unit tests were modified to check if the scheduler was changed
and everything runs.

### :page_facing_up: Release Notes

- Fixed an issue where the scheduler was not updated on maintenance update.
