### PR TITLE
Status subclass of IntEnum instead of Enum

### DIFF
--- a/models.py
+++ b/models.py
@@ -4,7 +4,7 @@ This module define models for the maintenance window itself and the
 scheduler.
 """
 import datetime
-from enum import Enum
+from enum import IntEnum
 from uuid import uuid4
 
 import pytz
@@ -18,7 +18,7 @@ from kytos.core.link import Link
 TIME_FMT = "%Y-%m-%dT%H:%M:%S%z"
 
 
-class Status(Enum):
+class Status(IntEnum):
     """Maintenance windows status."""
 
     PENDING = 0


### PR DESCRIPTION
This change allows Status to be JSON Serializable

### :bookmark_tabs: Description of the Change

Status was subclassing Enum, making it not JSON serializable.
Now it subclasses IntEnum, which is serializable.

### :page_facing_up: Release Notes

- Status subclasses IntEnum